### PR TITLE
refactor: 챌린지 중복 인증 검사 추가

### DIFF
--- a/src/main/java/ONDA/domain/challenge/repository/ChallengePostRepository.java
+++ b/src/main/java/ONDA/domain/challenge/repository/ChallengePostRepository.java
@@ -24,4 +24,11 @@ public interface ChallengePostRepository extends JpaRepository<ChallengePost,Lon
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate
     );
+    @Query("SELECT COUNT(p) > 0 FROM ChallengePost p " +
+            "WHERE p.author.id = :memberId " +
+            "AND p.challenge.id = :challengeId " +
+            "AND p.createDate = :today")
+    boolean existsByMemberAndChallengeAndDate(@Param("memberId") Long memberId,
+                                              @Param("challengeId") Long challengeId,
+                                              @Param("today") LocalDate today);
 }

--- a/src/main/java/ONDA/domain/challenge/service/impl/ChallengePostServiceImpl.java
+++ b/src/main/java/ONDA/domain/challenge/service/impl/ChallengePostServiceImpl.java
@@ -42,6 +42,13 @@ public class ChallengePostServiceImpl implements ChallengePostService {
         Challenge challenge = challengeRepository.findByIdAndProgressStatus(dto.getChallengeId(), ProgressStatus.ONGOING)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_CHALLENGE_FOUND));
 
+        LocalDate today = LocalDate.now();
+
+        boolean alreadyPosted = challengePostRepository.existsByMemberAndChallengeAndDate(memberId, challenge.getId(), today);
+        if (alreadyPosted) {
+            throw new BusinessException(ErrorCode.ALREADY_POSTED_TODAY);
+        }
+
         ChallengePost challengePost = ChallengePost.builder()
                         .author(member)
                         .challenge(challenge)

--- a/src/main/java/ONDA/global/exception/ErrorCode.java
+++ b/src/main/java/ONDA/global/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     NOT_CHALLENGE_POST_FOUND("CHALLENGE-POST-404", "챌린지 인증글을 찾을 수 없습니다."),
     CHALLENGE_ALREADY_REVIEWED("CHALLENGE001", "이미 심사 완료된 챌린지는 상태 변경이 불가합니다."),
     ALREADY_VOTED("VOTE001", "이미 투표하였습니다."),
+    ALREADY_POSTED_TODAY("CHALLENGEPOST001","이미 오늘 인증글을 작성했습니다."),
 
 
     OWNER_MISMATCH("OWNER_MISMATCH","삭제 권한 없음(해당 글의 작성자가 아님)."),


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호를 적어주세요. -->
- 관련 이슈: #10 

---

## 📝 변경 내용
<!-- 주요 변경사항을 간단히 정리해주세요. -->
-챌린지 하나 당 하루에 한 번 인증할 수 있도록 한다.

---

## 🔍 테스트 방법
<!-- 어떻게 테스트했는지, 재현 방법 등을 적어주세요. -->
1.
2.
3.

---

## ✅ 체크리스트
- [ ] 관련 이슈에 링크 달았는가? (Closes #이슈번호)
- [ ] 빌드 및 테스트 통과 확인
- [ ] 리뷰어가 이해할 수 있게 충분한 설명 작성
- [ ] 필요한 경우 스크린샷/로그 첨부

---

## 📸 스크린샷 (선택)
<!-- UI 변경이나 API 응답 예시가 있으면 첨부 -->
